### PR TITLE
design_database

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 |password|string|null: false|
 
 ### Association
-- belongs_to :message
-- has_many: :group_users
-- has_many: :group
+- has_one :messages
+- has_many: :user_groups
+- has_many: :groups, through: :user_groups
 
 ## groupテーブル
 |Column|Type|Options|
@@ -19,9 +19,9 @@
 |name|string|null: false|
 
 ### Association
-- belongs_to: :message
-- has_many :user_group
-- has_many: :user
+- has_one: :message
+- has_many :user_groups
+- has_many: :users, through: :user_groups
 
 
 ## user_groupテーブル
@@ -31,8 +31,8 @@
 |group_id|integer|foreign_key: true|
 
 ### Association
-- belongs_to :user_id
-- belongs_to :group_id
+- belongs_to :user
+- belongs_to :group
 
 
 ## messageテーブル
@@ -44,7 +44,7 @@
 |image|string||
 
 ### Association
-- belongs_to :group_id
-- belongs_to :user_id
+- belongs_to :group
+- belongs_to :user
 
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 ## user_groupテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|foreign_key: true|
-|group_id|integer|foreign_key: true|
+|user_id|refference|foreign_key: true|
+|group_id|refference|foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -38,8 +38,8 @@
 ## messageテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|foreign_key: true|
-|group_id|integer|foreign_key: true|
+|user_id|refference|foreign_key: true|
+|group_id|refference|foreign_key: true|
 |text|string||
 |image|string||
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ### Association
 - belongs_to :user_group
 
-## groupテーブル
 
+## groupテーブル
 |Column|Type|Options|
 |------|----|-------|
 |group_name|string|null: false|
@@ -20,8 +20,8 @@
 ### Association
 - belongs_to :user_group
 
-## user_groupテーブル
 
+## user_groupテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|foreign_key: true|
@@ -33,7 +33,6 @@
 
 
 ## chatテーブル
-
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@
 |password|string|null: false|
 
 ### Association
-- belongs_to :user_group
-
+- belongs_to :message
+- hasm_one: :group_users
 
 ## groupテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
-- belongs_to :user_group
+- belongs_to: :message
+- hasm_one :user_group
 
 
 ## user_groupテーブル
@@ -28,19 +29,20 @@
 |group_id|integer|foreign_key: true|
 
 ### Association
-- belongs_to :user
-- belongs_to :group
+- belongs_to :user_id
+- belongs_to :group_id
 
 
-## chatテーブル
+## messageテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|foreign_key: true|
 |group_id|integer|foreign_key: true|
 |text|string|null: false|
+|image|string||
 
 ### Association
-- belongs_to :group
-- belongs_to :user
+- belongs_to :group_id
+- belongs_to :user_id
 
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 |password|string|null: false|
 
 ### Association
-- has_one :messages
-- has_many: :user_groups
-- has_many: :groups, through: :user_groups
+- has_many :messages
+- has_many :user_groups
+- has_many :groups, through: :user_groups
 
 ## groupテーブル
 |Column|Type|Options|
@@ -19,9 +19,9 @@
 |name|string|null: false|
 
 ### Association
-- has_one: :message
+- has_many :messages
 - has_many :user_groups
-- has_many: :users, through: :user_groups
+- has_many :users, through: :user_groups
 
 
 ## user_groupテーブル
@@ -40,7 +40,7 @@
 |------|----|-------|
 |user_id|integer|foreign_key: true|
 |group_id|integer|foreign_key: true|
-|text|string|null: false|
+|text|string||
 |image|string||
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ### Association
 - belongs_to: :message
-- hasm_one :user_group
+- has_many :user_group
 - has_many: :user
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 ### Association
 - belongs_to :message
-- hasm_one: :group_users
+- has_many: :group_users
+- has_many: :group
 
 ## groupテーブル
 |Column|Type|Options|
@@ -20,6 +21,7 @@
 ### Association
 - belongs_to: :message
 - hasm_one :user_group
+- has_many: :user
 
 
 ## user_groupテーブル


### PR DESCRIPTION
修正箇所

①userとgroupの中間テーブルが抜けている
user_groupテーブルを作成

②スペルミス
groupに修正

③必要のないカラムを削除
中間テーブルで管理するようにデータベースを変更
created_atやupdated_atで確認できるため削除

④アソシエーションの記載
userテーブルのアソシエーションを記載

⑤foreign_keyの記載
falseになるキーを削除